### PR TITLE
empty has been removed from ember 1.10

### DIFF
--- a/addon/retry-with-backoff.js
+++ b/addon/retry-with-backoff.js
@@ -2,7 +2,7 @@ import Em from 'ember';
 import delay from 'ember-delay/delay';
 
 var retryWithBackoff = function(callback, retryCountBeforeFailure, waitInMilliseconds) {
-  if(Em.empty(retryCountBeforeFailure)) {
+  if(Em.isEmpty(retryCountBeforeFailure)) {
     retryCountBeforeFailure = 5;
   }
   waitInMilliseconds = waitInMilliseconds || 250;


### PR DESCRIPTION
`empty` is not longer available in newer version of ember