### PR TITLE
Swapped Em.empty for Em.isEmpty

### DIFF
--- a/addon/retry-with-backoff.js
+++ b/addon/retry-with-backoff.js
@@ -2,7 +2,7 @@ import Em from 'ember';
 import delay from 'ember-delay/delay';
 
 var retryWithBackoff = function(callback, retryCountBeforeFailure, waitInMilliseconds) {
-  if(Em.empty(retryCountBeforeFailure)) {
+  if(Em.isEmpty(retryCountBeforeFailure)) {
     retryCountBeforeFailure = 5;
   }
   waitInMilliseconds = waitInMilliseconds || 250;

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "handlebars": "~1.3.0",
     "jquery": "^1.11.1",
-    "ember": "1.7.0",
+    "ember": "^1.7.0",
     "ember-resolver": "~0.1.7",
     "loader": "stefanpenner/loader.js#1.0.1",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
@@ -12,7 +12,5 @@
     "ember-qunit": "0.1.8",
     "ember-qunit-notifications": "0.0.4",
     "qunit": "~1.15.0"
-  },
-  "devDependencies": {
   }
 }


### PR DESCRIPTION
Em.empty is deprecated and has been removed from Ember 0.1.10