### PR TITLE
Pass 'abort' to callback

### DIFF
--- a/addon/retry-with-backoff.js
+++ b/addon/retry-with-backoff.js
@@ -26,7 +26,7 @@ export default function(callback, retryCountBeforeFailure, waitInMilliseconds){
     retryCountBeforeFailure = 5;
   }
   waitInMilliseconds = waitInMilliseconds || 250;
-  
+
   return new Em.RSVP.Promise(function(resolve, reject) {
     retryWithBackoff(
       callback, 
@@ -36,4 +36,4 @@ export default function(callback, retryCountBeforeFailure, waitInMilliseconds){
       reject
     );
   });
-};
+}

--- a/addon/retry-with-backoff.js
+++ b/addon/retry-with-backoff.js
@@ -1,23 +1,39 @@
 import Em from 'ember';
 import delay from 'ember-delay/delay';
 
-var retryWithBackoff = function(callback, retryCountBeforeFailure, waitInMilliseconds) {
-  if(Em.isEmpty(retryCountBeforeFailure)) {
-    retryCountBeforeFailure = 5;
-  }
-  waitInMilliseconds = waitInMilliseconds || 250;
-
-  return callback().catch(function(reason) {
+var retryWithBackoff = function(callback, retryCountBeforeFailure, waitInMilliseconds, resolve, reject) {
+  callback(reject).then(resolve).catch(function(reason) {
     if (retryCountBeforeFailure-- > 1) {
       waitInMilliseconds = waitInMilliseconds * 2;
 
       return delay(waitInMilliseconds).then(function() {
-        return retryWithBackoff(callback, retryCountBeforeFailure, waitInMilliseconds);
+        return retryWithBackoff(
+          callback, 
+          retryCountBeforeFailure, 
+          waitInMilliseconds, 
+          resolve, 
+          reject
+        );
       });
     }
 
-    throw reason;
+    reject(reason);
   });
 };
 
-export default retryWithBackoff;
+export default function(callback, retryCountBeforeFailure, waitInMilliseconds){
+  if(Em.isEmpty(retryCountBeforeFailure)) {
+    retryCountBeforeFailure = 5;
+  }
+  waitInMilliseconds = waitInMilliseconds || 250;
+  
+  return new Em.RSVP.Promise(function(resolve, reject) {
+    retryWithBackoff(
+      callback, 
+      retryCountBeforeFailure, 
+      waitInMilliseconds, 
+      resolve, 
+      reject
+    );
+  });
+};


### PR DESCRIPTION
Thanks for this awesome addon. I've been using it everywhere in my apps. I was missing a feature the other day tho that made it possible to abort a retry chain. Here's an example. 

The code below downloads the given url and returns its content, unless the status code is 401. If so, then it aborts, otherwise it continues as usual. I also changed it so that it doesn't raise an error when it fails after `n` retries. Instead it invokes the `reject` callback.

I didn't manage to run the specs for some reason. I just got an `Uncaught SyntaxError: Unexpected token {` error in the console. The code as been tested in one of my apps without any problems tho.

``` js
export default function(options) {
  return retryWithBackoff(function(abort){
    return new Promise(function(resolve, reject) {
      request(options, function(error, response, body){
        if(error) { return reject(error); }
        if(response.statusCode == 401) { 
          return abort("Permission problem");
        }

        if(response.statusCode != 200) { return reject(response); }

        resolve(body);
      });
    });
  }, 8, 100);
}
```
