### PR TITLE
Deprecation: run loop dot access

### DIFF
--- a/addon/delay.js
+++ b/addon/delay.js
@@ -1,11 +1,12 @@
-import Em from 'ember';
+import Em from "ember";
+import { later } from "@ember/runloop";
 
-export default function(milliseconds) {
-  if(milliseconds === undefined) {
+export default function (milliseconds) {
+  if (milliseconds === undefined) {
     milliseconds = 2000;
   }
 
-  return new Em.RSVP.Promise(function(resolve) {
-    Em.run.later(this, resolve, milliseconds);
+  return new Em.RSVP.Promise(function (resolve) {
+    later(this, resolve, milliseconds);
   });
 }


### PR DESCRIPTION
Removes deprecated use of `Em.run.later`

<img width="711" alt="Screenshot 2024-01-22 at 12 12 09" src="https://github.com/GavinJoyce/ember-backoff/assets/106588403/d7783f66-0f81-4c85-a58e-f31d89af50ae">
